### PR TITLE
Refatoração dos exemplos: inglês para português

### DIFF
--- a/documentacao/Exemplos/ex0.c
+++ b/documentacao/Exemplos/ex0.c
@@ -35,8 +35,7 @@ int main(void)
     // Posicao do jogador
     Vector2 posJog = {300, 300};
 
-    // Obstaculos
-    Rectangle obCinza = {100, 100, 150, 100};
+    Rectangle obstRet = {100, 100, 150, 100};
     Vector2 obRoxoCentro = {900, 350}; // Posicao do centro do circulo
     float obRoxoRaio = 100;
     bool roxoTaAndando = false;
@@ -78,10 +77,10 @@ int main(void)
            A magnitude desse vetor eh sqrt(1^2 + 1^2) = ~1.41 */
 
         ///Mover obstaculos====================================================
-        // Mover o cinza
+        // Mover o retangulo
         if (IsKeyPressed(KEY_SPACE)) {
-            obCinza.x += 10;
-            obCinza.height += 5;
+            obstRet.x += 10;
+            obstRet.height += 5;
         }
         // Mover o roxo
         if (IsKeyDown(KEY_SPACE)) {
@@ -107,8 +106,8 @@ int main(void)
             DrawCircleGradient(posJog.x, posJog.y,
                                RAIO_PLR, SKYBLUE, BLUE);
 
-            // Obstaculo Cinza
-            DrawRectangleRec(obCinza, GRAY);
+            // Obstaculo retangular
+            DrawRectangleRec(obstRet, GRAY);
 
             // Controles
             DrawText("Controles:\n"

--- a/documentacao/Exemplos/ex0.c
+++ b/documentacao/Exemplos/ex0.c
@@ -35,10 +35,13 @@ int main(void)
     // Posicao do jogador
     Vector2 posJog = {300, 300};
 
+    ///Obstaculos==============================================================
+    // Obstaculo retangular
     Rectangle obstRet = {100, 100, 150, 100};
-    Vector2 obRoxoCentro = {900, 350}; // Posicao do centro do circulo
-    float obRoxoRaio = 100;
-    bool roxoTaAndando = false;
+    // Obstaculo circular
+    Vector2 obstCircCentro = {900, 350}; // Posicao do centro do circulo
+    float obstCircRaio = 100;
+    bool obstCircTaAndando = false;
 
     /// [[[[[ End Initalization ]]]]]
 
@@ -82,13 +85,13 @@ int main(void)
             obstRet.x += 10;
             obstRet.height += 5;
         }
-        // Mover o roxo
+        // Mover o circulo
         if (IsKeyDown(KEY_SPACE)) {
-            roxoTaAndando = true;
-            obRoxoCentro.x -= VEL_ROXO * GetFrameTime();
-            obRoxoRaio -= VEL_ROXO / 5.0f * GetFrameTime();
+            obstCircTaAndando = true;
+            obstCircCentro.x -= VEL_ROXO * GetFrameTime();
+            obstCircRaio -= VEL_ROXO / 5.0f * GetFrameTime();
         } else {
-            roxoTaAndando = false;
+            obstCircTaAndando = false;
         }
         /// [[[[[ End Update ]]]]]
 
@@ -98,9 +101,9 @@ int main(void)
             // Pintar tudo (para formar o background)
             ClearBackground(DARKBROWN);
 
-            // Obstaculo Roxo
-            DrawCircleV(obRoxoCentro, obRoxoRaio,
-                        roxoTaAndando ? PURPLE : VIOLET);
+            // Obstaculo circular
+            DrawCircleV(obstCircCentro, obstCircRaio,
+                        obstCircTaAndando ? PURPLE : VIOLET);
 
             // Player
             DrawCircleGradient(posJog.x, posJog.y,
@@ -115,8 +118,8 @@ int main(void)
                      "Espaco para movimentar obstaculos", 200, 10, 19, MAROON);
 
             // Texto com raio do roxo
-            DrawText(TextFormat("Raio = %.1f", obRoxoRaio),
-                     obRoxoCentro.x, obRoxoCentro.y, 17, WHITE);
+            DrawText(TextFormat("Raio = %.1f", obstCircRaio),
+                     obstCircCentro.x, obstCircCentro.y, 17, WHITE);
 
             // FPS
             DrawFPS(10, 10);

--- a/documentacao/Exemplos/ex0.c
+++ b/documentacao/Exemplos/ex0.c
@@ -52,31 +52,31 @@ int main(void)
         ///Movimentacao do jogador==============================================
         /* A posicao para a qual vamos mover o jogador nesse frame,
            relativa ah posicao atual dele */
-        Vector2 playerMoveTo = Vector2Zero();
+        Vector2 posFutura = Vector2Zero();
 
-        if (IsKeyDown(KEY_A) || IsKeyDown(KEY_LEFT))  { playerMoveTo.x -= 1; }
-        if (IsKeyDown(KEY_D) || IsKeyDown(KEY_RIGHT)) { playerMoveTo.x += 1; }
-        if (IsKeyDown(KEY_W) || IsKeyDown(KEY_UP))    { playerMoveTo.y -= 1; }
-        if (IsKeyDown(KEY_S) || IsKeyDown(KEY_DOWN))  { playerMoveTo.y += 1; }
+        if (IsKeyDown(KEY_A) || IsKeyDown(KEY_LEFT))  { posFutura.x -= 1; }
+        if (IsKeyDown(KEY_D) || IsKeyDown(KEY_RIGHT)) { posFutura.x += 1; }
+        if (IsKeyDown(KEY_W) || IsKeyDown(KEY_UP))    { posFutura.y -= 1; }
+        if (IsKeyDown(KEY_S) || IsKeyDown(KEY_DOWN))  { posFutura.y += 1; }
 
         /* Se andarmos uma quantidade fixa por frame, a velocidade de movimento
            dependerah da frame rate. Para q isso nao aconteca, multiplicamos a
            quantidade que queremos mover por segundo (VEL_PLR) pela
            quantidade de segundos que o frame dura. O resultado eh a distancia
            q devemos mover no frame. */
-        playerMoveTo = Vector2Scale(playerMoveTo, VEL_PLR * GetFrameTime());
+        posFutura = Vector2Scale(posFutura, VEL_PLR * GetFrameTime());
 
         /* Transformar de coordenadas player para coordenadas world (i.e. antes
            era a partir da posicao atual do jogador, agora vai ser a partir da
            origem do world, assim como eh posJog) */
-        playerMoveTo = Vector2Add(posJog, playerMoveTo);
+        posFutura = Vector2Add(posJog, posFutura);
 
         // Finalmente, atualizar a posicao do jogador
-        posJog = playerMoveTo;
+        posJog = posFutura;
 
         /* Note que com esse algoritmo, o jogador anda 41% mais rapido se
            estiver andando na diagonal. Por exemplo: segurando D e S,
-           playerMoveTo eh {1.0f, 1.0f} antes de ser escalado.
+           posFutura eh {1.0f, 1.0f} antes de ser escalado.
            A magnitude desse vetor eh sqrt(1^2 + 1^2) = ~1.41 */
 
         ///Mover obstaculos====================================================

--- a/documentacao/Exemplos/ex0.c
+++ b/documentacao/Exemplos/ex0.c
@@ -105,7 +105,7 @@ int main(void)
             DrawCircleV(obstCircCentro, obstCircRaio,
                         obstCircTaAndando ? PURPLE : VIOLET);
 
-            // Player
+            // Jogador
             DrawCircleGradient(posJog.x, posJog.y, RAIO_PLR, SKYBLUE, BLUE);
 
             // Obstaculo retangular

--- a/documentacao/Exemplos/ex0.c
+++ b/documentacao/Exemplos/ex0.c
@@ -19,8 +19,8 @@ Exemplo 0
 #include "raylib.h"
 #include "raymath.h"
 
-#define VEL_PLR 150.0f // Velocidade do jogador (por segundo)
-#define RAIO_PLR 30.0f // Raio do circulo do jogador
+#define VEL_JOG 150.0f // Velocidade do jogador (por segundo)
+#define RAIO_JOG 30.0f // Raio do circulo do jogador
 
 #define VEL_CIRC 40.0f // Velocidade do obstaculo circular (por segundo)
 
@@ -61,10 +61,10 @@ int main(void)
 
         /* Se andarmos uma quantidade fixa por frame, a velocidade de movimento
            dependerah da frame rate. Para q isso nao aconteca, multiplicamos a
-           quantidade que queremos mover por segundo (VEL_PLR) pela
+           quantidade que queremos mover por segundo (VEL_JOG) pela
            quantidade de segundos que o frame dura. O resultado eh a distancia
            q devemos mover no frame. */
-        posFutura = Vector2Scale(posFutura, VEL_PLR * GetFrameTime());
+        posFutura = Vector2Scale(posFutura, VEL_JOG * GetFrameTime());
 
         /* Transformar de coordenadas player para coordenadas world (i.e. antes
            era a partir da posicao atual do jogador, agora vai ser a partir da
@@ -106,7 +106,7 @@ int main(void)
                         obstCircTaAndando ? PURPLE : VIOLET);
 
             // Jogador
-            DrawCircleGradient(posJog.x, posJog.y, RAIO_PLR, SKYBLUE, BLUE);
+            DrawCircleGradient(posJog.x, posJog.y, RAIO_JOG, SKYBLUE, BLUE);
 
             // Obstaculo retangular
             DrawRectangleRec(obstRet, GRAY);

--- a/documentacao/Exemplos/ex0.c
+++ b/documentacao/Exemplos/ex0.c
@@ -19,10 +19,10 @@ Exemplo 0
 #include "raylib.h"
 #include "raymath.h"
 
-#define VEL_PLR 150.0f // Velocidade de movimento do player (por segundo)
-#define RAIO_PLR 30.0f // Raio do circulo do player
+#define VEL_PLR 150.0f // Velocidade do jogador (por segundo)
+#define RAIO_PLR 30.0f // Raio do circulo do jogador
 
-#define VEL_ROXO 40.0f // Velocidade do movimento do circulo roxo (por segundo)
+#define VEL_ROXO 40.0f // Velocidade do obstaculo circular (por segundo)
 
 int main(void)
 {

--- a/documentacao/Exemplos/ex0.c
+++ b/documentacao/Exemplos/ex0.c
@@ -106,8 +106,7 @@ int main(void)
                         obstCircTaAndando ? PURPLE : VIOLET);
 
             // Player
-            DrawCircleGradient(posJog.x, posJog.y,
-                               RAIO_PLR, SKYBLUE, BLUE);
+            DrawCircleGradient(posJog.x, posJog.y, RAIO_PLR, SKYBLUE, BLUE);
 
             // Obstaculo retangular
             DrawRectangleRec(obstRet, GRAY);

--- a/documentacao/Exemplos/ex0.c
+++ b/documentacao/Exemplos/ex0.c
@@ -117,7 +117,7 @@ int main(void)
                      "WASD/Setas para andar\n"
                      "Espaco para movimentar obstaculos", 200, 10, 19, MAROON);
 
-            // Texto com raio do roxo
+            // Texto com raio do obstaculo
             DrawText(TextFormat("Raio = %.1f", obstCircRaio),
                      obstCircCentro.x, obstCircCentro.y, 17, WHITE);
 

--- a/documentacao/Exemplos/ex0.c
+++ b/documentacao/Exemplos/ex0.c
@@ -33,7 +33,7 @@ int main(void)
     SetTargetFPS(60);
     ///========================================================================
     // Posicao do jogador
-    Vector2 playerPos = {300, 300};
+    Vector2 posJog = {300, 300};
 
     // Obstaculos
     Rectangle obCinza = {100, 100, 150, 100};
@@ -66,11 +66,11 @@ int main(void)
 
         /* Transformar de coordenadas player para coordenadas world (i.e. antes
            era a partir da posicao atual do player, agora vai ser a partir da
-           origem do world, assim como eh playerPos) */
-        playerMoveTo = Vector2Add(playerPos, playerMoveTo);
+           origem do world, assim como eh posJog) */
+        playerMoveTo = Vector2Add(posJog, playerMoveTo);
 
         // Finalmente, atualizar a posicao do player
-        playerPos = playerMoveTo;
+        posJog = playerMoveTo;
 
         /* Note que com esse algoritmo, o player anda 41% mais rapido se
            estiver andando na diagonal. Por exemplo: segurando D e S,
@@ -104,7 +104,7 @@ int main(void)
                         roxoTaAndando ? PURPLE : VIOLET);
 
             // Player
-            DrawCircleGradient(playerPos.x, playerPos.y,
+            DrawCircleGradient(posJog.x, posJog.y,
                                RAIO_PLR, SKYBLUE, BLUE);
 
             // Obstaculo Cinza

--- a/documentacao/Exemplos/ex0.c
+++ b/documentacao/Exemplos/ex0.c
@@ -49,9 +49,9 @@ int main(void)
     while (!WindowShouldClose()) { // Detect window close button or ESC key
 
         /// [[[[[ Update ]]]]]
-        ///Movimentacao do player==============================================
-        /* A posicao para a qual vamos mover o player nesse frame,
-           relativa ah posicao atual do player */
+        ///Movimentacao do jogador==============================================
+        /* A posicao para a qual vamos mover o jogador nesse frame,
+           relativa ah posicao atual dele */
         Vector2 playerMoveTo = Vector2Zero();
 
         if (IsKeyDown(KEY_A) || IsKeyDown(KEY_LEFT))  { playerMoveTo.x -= 1; }
@@ -67,14 +67,14 @@ int main(void)
         playerMoveTo = Vector2Scale(playerMoveTo, VEL_PLR * GetFrameTime());
 
         /* Transformar de coordenadas player para coordenadas world (i.e. antes
-           era a partir da posicao atual do player, agora vai ser a partir da
+           era a partir da posicao atual do jogador, agora vai ser a partir da
            origem do world, assim como eh posJog) */
         playerMoveTo = Vector2Add(posJog, playerMoveTo);
 
-        // Finalmente, atualizar a posicao do player
+        // Finalmente, atualizar a posicao do jogador
         posJog = playerMoveTo;
 
-        /* Note que com esse algoritmo, o player anda 41% mais rapido se
+        /* Note que com esse algoritmo, o jogador anda 41% mais rapido se
            estiver andando na diagonal. Por exemplo: segurando D e S,
            playerMoveTo eh {1.0f, 1.0f} antes de ser escalado.
            A magnitude desse vetor eh sqrt(1^2 + 1^2) = ~1.41 */

--- a/documentacao/Exemplos/ex0.c
+++ b/documentacao/Exemplos/ex0.c
@@ -22,7 +22,7 @@ Exemplo 0
 #define VEL_PLR 150.0f // Velocidade do jogador (por segundo)
 #define RAIO_PLR 30.0f // Raio do circulo do jogador
 
-#define VEL_ROXO 40.0f // Velocidade do obstaculo circular (por segundo)
+#define VEL_CIRC 40.0f // Velocidade do obstaculo circular (por segundo)
 
 int main(void)
 {
@@ -88,8 +88,8 @@ int main(void)
         // Mover o circulo
         if (IsKeyDown(KEY_SPACE)) {
             obstCircTaAndando = true;
-            obstCircCentro.x -= VEL_ROXO * GetFrameTime();
-            obstCircRaio -= VEL_ROXO / 5.0f * GetFrameTime();
+            obstCircCentro.x -= VEL_CIRC * GetFrameTime();
+            obstCircRaio -= VEL_CIRC / 5.0f * GetFrameTime();
         } else {
             obstCircTaAndando = false;
         }

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -112,7 +112,7 @@ int main(void)
 void MoverJog(Vector2* posAtual, Rectangle obRet,
                 Vector2 obCircCentro, float obstRaio)
 {
-    // Posicao do player no proximo frame em relacao ah posicao atual
+    // Posicao futura do jogador em relacao ah posicao atual
     Vector2 playerMoveTo = Vector2Zero();
 
     if (IsKeyDown(KEY_A) || IsKeyDown(KEY_LEFT))  { playerMoveTo.x -= 1; }

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -24,8 +24,8 @@ Novidades em relacao ao Exemplo 0:
 #include "raylib.h"
 #include "raymath.h"
 
-#define VEL_PLR 150.0f // Velocidade do jogador (por segundo)
-#define RAIO_PLR 30.0f // Raio do circulo do jogador
+#define VEL_JOG 150.0f // Velocidade do jogador (por segundo)
+#define RAIO_JOG 30.0f // Raio do circulo do jogador
 
 #define VEL_CIRC 40.0f // Velocidade do obstaculo circular (por segundo)
 
@@ -82,7 +82,7 @@ int main(void)
                         obstCircTaAndando ? PURPLE : VIOLET);
 
             // Jogador
-            DrawCircleGradient(posJog.x, posJog.y, RAIO_PLR, SKYBLUE, BLUE);
+            DrawCircleGradient(posJog.x, posJog.y, RAIO_JOG, SKYBLUE, BLUE);
 
             // Obstaculo retangular
             DrawRectangleRec(obstRet, GRAY);
@@ -119,7 +119,7 @@ void MoverJog(Vector2* posAtual, Rectangle obRet,
     if (IsKeyDown(KEY_W) || IsKeyDown(KEY_UP))    { posFutura.y -= 1; }
     if (IsKeyDown(KEY_S) || IsKeyDown(KEY_DOWN))  { posFutura.y += 1; }
 
-    posFutura = Vector2Scale(posFutura, VEL_PLR * GetFrameTime());
+    posFutura = Vector2Scale(posFutura, VEL_JOG * GetFrameTime());
 
     // Transformar para coordenadas world
     posFutura = Vector2Add(*posAtual, posFutura);
@@ -135,8 +135,8 @@ void MoverJog(Vector2* posAtual, Rectangle obRet,
     obstRaio = (obstRaio < 0) ? 0 : obstRaio;
 
     // Verificar colisao
-    if (!CheckCollisionCircleRec(posFutura, RAIO_PLR, obRet) &&
-        !CheckCollisionCircles(posFutura, RAIO_PLR, obCircCentro, obstRaio))
+    if (!CheckCollisionCircleRec(posFutura, RAIO_JOG, obRet) &&
+        !CheckCollisionCircles(posFutura, RAIO_JOG, obCircCentro, obstRaio))
     {
         // Atualizar a posicao do jogador
         *posAtual = posFutura;

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -16,8 +16,8 @@ Exemplo 1
 
 Novidades em relacao ao Exemplo 0:
 - Colisao com os obstaculos
-- MovePlayer()
-- MoveObstacles()
+- MoverJog()
+- MoverObst()
 
 ******************************************************************************/
 
@@ -30,11 +30,11 @@ Novidades em relacao ao Exemplo 0:
 #define VEL_ROXO 40.0f // Velocidade do movimento do circulo roxo (por segundo)
 
 // Move o jogador
-void MovePlayer(Vector2* playerPos, Rectangle obRet,
+void MoverJog(Vector2* posAtual, Rectangle obRet,
                 Vector2 obCircCentro, float raio);
 
 // Move os obstaculos
-void MoveObstacles(Rectangle* obCinza, Vector2* obRoxoCentro,
+void MoverObst(Rectangle* obCinza, Vector2* obRoxoCentro,
                    float* raio, bool* roxoTaAndando);
 
 int main(void)
@@ -46,7 +46,7 @@ int main(void)
     SetTargetFPS(60);
     ///========================================================================
     // Posicao do jogador
-    Vector2 playerPos = {300, 300};
+    Vector2 posJog = {300, 300};
 
     // Obstaculos
     Rectangle obCinza = {100, 100, 150, 100};
@@ -62,10 +62,10 @@ int main(void)
         /// [[[[[ Update ]]]]]
 
         // Mover player
-        MovePlayer(&playerPos, obCinza, obRoxoCentro, obRoxoRaio);
+        MoverJog(&posJog, obCinza, obRoxoCentro, obRoxoRaio);
 
         // Mover obstaculos
-        MoveObstacles(&obCinza, &obRoxoCentro, &obRoxoRaio, &roxoTaAndando);
+        MoverObst(&obCinza, &obRoxoCentro, &obRoxoRaio, &roxoTaAndando);
 
         /// [[[[[ End Update ]]]]]
 
@@ -80,7 +80,7 @@ int main(void)
                         roxoTaAndando ? PURPLE : VIOLET);
 
             // Player
-            DrawCircleGradient(playerPos.x, playerPos.y,
+            DrawCircleGradient(posJog.x, posJog.y,
                                RAIO_PLR, SKYBLUE, BLUE);
 
             // Obstaculo Cinza
@@ -107,7 +107,7 @@ int main(void)
 }
 
 
-void MovePlayer(Vector2* playerPos, Rectangle obRet,
+void MoverJog(Vector2* posAtual, Rectangle obRet,
                 Vector2 obCircCentro, float raio)
 {
     // Posicao do player no proximo frame em relacao ah posicao atual
@@ -121,7 +121,7 @@ void MovePlayer(Vector2* playerPos, Rectangle obRet,
     playerMoveTo = Vector2Scale(playerMoveTo, VEL_PLR * GetFrameTime());
 
     // Transformar para coordenadas world
-    playerMoveTo = Vector2Add(*playerPos, playerMoveTo);
+    playerMoveTo = Vector2Add(*posAtual, playerMoveTo);
 
     /* Note que com esse algoritmo, o player anda 41% mais rapido se
        estiver andando na diagonal. Por exemplo: segurando D e S,
@@ -137,11 +137,11 @@ void MovePlayer(Vector2* playerPos, Rectangle obRet,
         !CheckCollisionCircles(playerMoveTo, RAIO_PLR, obCircCentro, raio))
     {
         // Atualizar a posicao do player
-        *playerPos = playerMoveTo;
+        *posAtual = playerMoveTo;
     }
 }
 
-void MoveObstacles(Rectangle* obCinza, Vector2* obRoxoCentro,
+void MoverObst(Rectangle* obCinza, Vector2* obRoxoCentro,
                    float* raio, bool* roxoTaAndando)
 {
     // Mover o cinza

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -63,7 +63,7 @@ int main(void)
 
         /// [[[[[ Update ]]]]]
 
-        // Mover player
+        // Mover jogador
         MoverJog(&posJog, obstRet, obstCircCentro, obstCircRaio);
 
         // Mover obstaculos
@@ -125,7 +125,7 @@ void MoverJog(Vector2* posAtual, Rectangle obRet,
     // Transformar para coordenadas world
     playerMoveTo = Vector2Add(*posAtual, playerMoveTo);
 
-    /* Note que com esse algoritmo, o player anda 41% mais rapido se
+    /* Note que com esse algoritmo, o jogador anda 41% mais rapido se
        estiver andando na diagonal. Por exemplo: segurando D e S,
        playerMoveTo eh {1.0f, 1.0f} antes de ser escalado.
        A magnitude desse vetor eh sqrt(1^2 + 1^2) = ~1.41 */
@@ -138,7 +138,7 @@ void MoverJog(Vector2* posAtual, Rectangle obRet,
     if (!CheckCollisionCircleRec(playerMoveTo, RAIO_PLR, obRet) &&
         !CheckCollisionCircles(playerMoveTo, RAIO_PLR, obCircCentro, obstRaio))
     {
-        // Atualizar a posicao do player
+        // Atualizar a posicao do jogador
         *posAtual = playerMoveTo;
     }
 }

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -77,7 +77,7 @@ int main(void)
             // Pintar tudo (para formar o background)
             ClearBackground(DARKBROWN);
 
-            // Obstaculo Roxo
+            // Obstaculo circular
             DrawCircleV(obstCircCentro, obstCircRaio,
                         obstCircTaAndando ? PURPLE : VIOLET);
 

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -151,7 +151,7 @@ void MoverObst(Rectangle* obstRet, Vector2* circCentro,
         obstRet->x += 10;
         obstRet->height += 5;
     }
-    // Mover o roxo
+    // Mover o circulo
     if (IsKeyDown(KEY_SPACE)) {
         *obstCircTaAndando = true;
         circCentro->x -= VEL_CIRC * GetFrameTime();

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -24,10 +24,10 @@ Novidades em relacao ao Exemplo 0:
 #include "raylib.h"
 #include "raymath.h"
 
-#define VEL_PLR 150.0f // Velocidade de movimento do player (por segundo)
-#define RAIO_PLR 30.0f // Raio do circulo do player
+#define VEL_PLR 150.0f // Velocidade do jogador (por segundo)
+#define RAIO_PLR 30.0f // Raio do circulo do jogador
 
-#define VEL_ROXO 40.0f // Velocidade do movimento do circulo roxo (por segundo)
+#define VEL_ROXO 40.0f // Velocidade do obstaculo circular (por segundo)
 
 // Move o jogador
 void MoverJog(Vector2* posAtual, Rectangle obRet,

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -112,21 +112,21 @@ void MoverJog(Vector2* posAtual, Rectangle obRet,
                 Vector2 obCircCentro, float obstRaio)
 {
     // Posicao futura do jogador em relacao ah posicao atual
-    Vector2 playerMoveTo = Vector2Zero();
+    Vector2 posFutura = Vector2Zero();
 
-    if (IsKeyDown(KEY_A) || IsKeyDown(KEY_LEFT))  { playerMoveTo.x -= 1; }
-    if (IsKeyDown(KEY_D) || IsKeyDown(KEY_RIGHT)) { playerMoveTo.x += 1; }
-    if (IsKeyDown(KEY_W) || IsKeyDown(KEY_UP))    { playerMoveTo.y -= 1; }
-    if (IsKeyDown(KEY_S) || IsKeyDown(KEY_DOWN))  { playerMoveTo.y += 1; }
+    if (IsKeyDown(KEY_A) || IsKeyDown(KEY_LEFT))  { posFutura.x -= 1; }
+    if (IsKeyDown(KEY_D) || IsKeyDown(KEY_RIGHT)) { posFutura.x += 1; }
+    if (IsKeyDown(KEY_W) || IsKeyDown(KEY_UP))    { posFutura.y -= 1; }
+    if (IsKeyDown(KEY_S) || IsKeyDown(KEY_DOWN))  { posFutura.y += 1; }
 
-    playerMoveTo = Vector2Scale(playerMoveTo, VEL_PLR * GetFrameTime());
+    posFutura = Vector2Scale(posFutura, VEL_PLR * GetFrameTime());
 
     // Transformar para coordenadas world
-    playerMoveTo = Vector2Add(*posAtual, playerMoveTo);
+    posFutura = Vector2Add(*posAtual, posFutura);
 
     /* Note que com esse algoritmo, o jogador anda 41% mais rapido se
        estiver andando na diagonal. Por exemplo: segurando D e S,
-       playerMoveTo eh {1.0f, 1.0f} antes de ser escalado.
+       posFutura eh {1.0f, 1.0f} antes de ser escalado.
        A magnitude desse vetor eh sqrt(1^2 + 1^2) = ~1.41 */
 
     /* Se o raio for menor que 0, tornah-lo 0. Note que isso nao afeta nada
@@ -134,11 +134,11 @@ void MoverJog(Vector2* posAtual, Rectangle obRet,
     obstRaio = (obstRaio < 0) ? 0 : obstRaio;
 
     // Verificar colisao
-    if (!CheckCollisionCircleRec(playerMoveTo, RAIO_PLR, obRet) &&
-        !CheckCollisionCircles(playerMoveTo, RAIO_PLR, obCircCentro, obstRaio))
+    if (!CheckCollisionCircleRec(posFutura, RAIO_PLR, obRet) &&
+        !CheckCollisionCircles(posFutura, RAIO_PLR, obCircCentro, obstRaio))
     {
         // Atualizar a posicao do jogador
-        *posAtual = playerMoveTo;
+        *posAtual = posFutura;
     }
 }
 

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -93,7 +93,7 @@ int main(void)
                      "WASD/Setas para andar\n"
                      "Espaco para movimentar obstaculos", 200, 10, 19, MAROON);
 
-            // Texto com raio do roxo
+            // Texto com raio do obstaculo
             DrawText(TextFormat("Raio = %.1f", obstCircRaio),
                      obstCircCentro.x, obstCircCentro.y, 17, WHITE);
 

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -27,7 +27,7 @@ Novidades em relacao ao Exemplo 0:
 #define VEL_PLR 150.0f // Velocidade do jogador (por segundo)
 #define RAIO_PLR 30.0f // Raio do circulo do jogador
 
-#define VEL_ROXO 40.0f // Velocidade do obstaculo circular (por segundo)
+#define VEL_CIRC 40.0f // Velocidade do obstaculo circular (por segundo)
 
 // Move o jogador
 void MoverJog(Vector2* posAtual, Rectangle obRet,
@@ -154,8 +154,8 @@ void MoverObst(Rectangle* obstRet, Vector2* circCentro,
     // Mover o roxo
     if (IsKeyDown(KEY_SPACE)) {
         *obstCircTaAndando = true;
-        circCentro->x -= VEL_ROXO * GetFrameTime();
-        *raio -= VEL_ROXO / 5.0f * GetFrameTime();
+        circCentro->x -= VEL_CIRC * GetFrameTime();
+        *raio -= VEL_CIRC / 5.0f * GetFrameTime();
     } else {
         *obstCircTaAndando = false;
     }

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -49,7 +49,7 @@ int main(void)
     Vector2 posJog = {300, 300};
 
     // Obstaculos
-    Rectangle obCinza = {100, 100, 150, 100};
+    Rectangle obstRet = {100, 100, 150, 100};
     Vector2 obRoxoCentro = {900, 350}; // Posicao do centro do circulo
     float obRoxoRaio = 100;
     bool roxoTaAndando = false;
@@ -62,10 +62,10 @@ int main(void)
         /// [[[[[ Update ]]]]]
 
         // Mover player
-        MoverJog(&posJog, obCinza, obRoxoCentro, obRoxoRaio);
+        MoverJog(&posJog, obstRet, obRoxoCentro, obRoxoRaio);
 
         // Mover obstaculos
-        MoverObst(&obCinza, &obRoxoCentro, &obRoxoRaio, &roxoTaAndando);
+        MoverObst(&obstRet, &obRoxoCentro, &obRoxoRaio, &roxoTaAndando);
 
         /// [[[[[ End Update ]]]]]
 
@@ -83,8 +83,8 @@ int main(void)
             DrawCircleGradient(posJog.x, posJog.y,
                                RAIO_PLR, SKYBLUE, BLUE);
 
-            // Obstaculo Cinza
-            DrawRectangleRec(obCinza, GRAY);
+            // Obstaculo retangular
+            DrawRectangleRec(obstRet, GRAY);
 
             // Controles
             DrawText("Controles:\n"

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -82,8 +82,7 @@ int main(void)
                         obstCircTaAndando ? PURPLE : VIOLET);
 
             // Player
-            DrawCircleGradient(posJog.x, posJog.y,
-                               RAIO_PLR, SKYBLUE, BLUE);
+            DrawCircleGradient(posJog.x, posJog.y, RAIO_PLR, SKYBLUE, BLUE);
 
             // Obstaculo retangular
             DrawRectangleRec(obstRet, GRAY);

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -81,7 +81,7 @@ int main(void)
             DrawCircleV(obstCircCentro, obstCircRaio,
                         obstCircTaAndando ? PURPLE : VIOLET);
 
-            // Player
+            // Jogador
             DrawCircleGradient(posJog.x, posJog.y, RAIO_PLR, SKYBLUE, BLUE);
 
             // Obstaculo retangular

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -35,7 +35,7 @@ void MoverJog(Vector2* posAtual, Rectangle obRet,
 
 // Move os obstaculos
 void MoverObst(Rectangle* obstRet, Vector2* circCentro,
-                   float* raio, bool* roxoTaAndando);
+                   float* raio, bool* obstCircTaAndando);
 
 int main(void)
 {
@@ -67,7 +67,7 @@ int main(void)
         MoverJog(&posJog, obstRet, obstCircCentro, obstCircRaio);
 
         // Mover obstaculos
-        MoverObst(&obstRet, &obstCircCentro, &obstCircRaio, &roxoTaAndando);
+        MoverObst(&obstRet, &obstCircCentro, &obstCircRaio, &obstCircTaAndando);
 
         /// [[[[[ End Update ]]]]]
 
@@ -79,7 +79,7 @@ int main(void)
 
             // Obstaculo Roxo
             DrawCircleV(obstCircCentro, obstCircRaio,
-                        roxoTaAndando ? PURPLE : VIOLET);
+                        obstCircTaAndando ? PURPLE : VIOLET);
 
             // Player
             DrawCircleGradient(posJog.x, posJog.y,
@@ -144,7 +144,7 @@ void MoverJog(Vector2* posAtual, Rectangle obRet,
 }
 
 void MoverObst(Rectangle* obstRet, Vector2* circCentro,
-                   float* raio, bool* roxoTaAndando)
+                   float* raio, bool* obstCircTaAndando)
 {
     // Mover o retangulo
     if (IsKeyPressed(KEY_SPACE)) {
@@ -153,11 +153,11 @@ void MoverObst(Rectangle* obstRet, Vector2* circCentro,
     }
     // Mover o roxo
     if (IsKeyDown(KEY_SPACE)) {
-        *roxoTaAndando = true;
+        *obstCircTaAndando = true;
         circCentro->x -= VEL_ROXO * GetFrameTime();
         *raio -= VEL_ROXO / 5.0f * GetFrameTime();
     } else {
-        *roxoTaAndando = false;
+        *obstCircTaAndando = false;
     }
 }
 

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -34,7 +34,7 @@ void MoverJog(Vector2* posAtual, Rectangle obRet,
                 Vector2 obCircCentro, float raio);
 
 // Move os obstaculos
-void MoverObst(Rectangle* obCinza, Vector2* obRoxoCentro,
+void MoverObst(Rectangle* obstRet, Vector2* obRoxoCentro,
                    float* raio, bool* roxoTaAndando);
 
 int main(void)
@@ -141,13 +141,13 @@ void MoverJog(Vector2* posAtual, Rectangle obRet,
     }
 }
 
-void MoverObst(Rectangle* obCinza, Vector2* obRoxoCentro,
+void MoverObst(Rectangle* obstRet, Vector2* obRoxoCentro,
                    float* raio, bool* roxoTaAndando)
 {
-    // Mover o cinza
+    // Mover o retangulo
     if (IsKeyPressed(KEY_SPACE)) {
-        obCinza->x += 10;
-        obCinza->height += 5;
+        obstRet->x += 10;
+        obstRet->height += 5;
     }
     // Mover o roxo
     if (IsKeyDown(KEY_SPACE)) {

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -130,7 +130,8 @@ void MoverJog(Vector2* posAtual, Rectangle obRet,
        A magnitude desse vetor eh sqrt(1^2 + 1^2) = ~1.41 */
 
     /* Se o raio for menor que 0, tornah-lo 0. Note que isso nao afeta nada
-       fora da funcao (pq obstRaio nao eh ponteiro). */
+       fora dessa funcao (pq obstRaio nao eh ponteiro). Isso eh necessario pq a
+       funcao de checar colisao buga se for fornecida um raio negativo. */
     obstRaio = (obstRaio < 0) ? 0 : obstRaio;
 
     // Verificar colisao

--- a/documentacao/Exemplos/ex1.c
+++ b/documentacao/Exemplos/ex1.c
@@ -31,10 +31,10 @@ Novidades em relacao ao Exemplo 0:
 
 // Move o jogador
 void MoverJog(Vector2* posAtual, Rectangle obRet,
-                Vector2 obCircCentro, float raio);
+                Vector2 obCircCentro, float obstRaio);
 
 // Move os obstaculos
-void MoverObst(Rectangle* obstRet, Vector2* obRoxoCentro,
+void MoverObst(Rectangle* obstRet, Vector2* circCentro,
                    float* raio, bool* roxoTaAndando);
 
 int main(void)
@@ -48,11 +48,13 @@ int main(void)
     // Posicao do jogador
     Vector2 posJog = {300, 300};
 
-    // Obstaculos
+    ///Obstaculos==============================================================
+    // Obstaculo retangular
     Rectangle obstRet = {100, 100, 150, 100};
-    Vector2 obRoxoCentro = {900, 350}; // Posicao do centro do circulo
-    float obRoxoRaio = 100;
-    bool roxoTaAndando = false;
+    // Obstaculo circular
+    Vector2 obstCircCentro = {900, 350}; // Posicao do centro do circulo
+    float obstCircRaio = 100;
+    bool obstCircTaAndando = false;
 
     /// [[[[[ End Initalization ]]]]]
 
@@ -62,10 +64,10 @@ int main(void)
         /// [[[[[ Update ]]]]]
 
         // Mover player
-        MoverJog(&posJog, obstRet, obRoxoCentro, obRoxoRaio);
+        MoverJog(&posJog, obstRet, obstCircCentro, obstCircRaio);
 
         // Mover obstaculos
-        MoverObst(&obstRet, &obRoxoCentro, &obRoxoRaio, &roxoTaAndando);
+        MoverObst(&obstRet, &obstCircCentro, &obstCircRaio, &roxoTaAndando);
 
         /// [[[[[ End Update ]]]]]
 
@@ -76,7 +78,7 @@ int main(void)
             ClearBackground(DARKBROWN);
 
             // Obstaculo Roxo
-            DrawCircleV(obRoxoCentro, obRoxoRaio,
+            DrawCircleV(obstCircCentro, obstCircRaio,
                         roxoTaAndando ? PURPLE : VIOLET);
 
             // Player
@@ -92,8 +94,8 @@ int main(void)
                      "Espaco para movimentar obstaculos", 200, 10, 19, MAROON);
 
             // Texto com raio do roxo
-            DrawText(TextFormat("Raio = %.1f", obRoxoRaio),
-                     obRoxoCentro.x, obRoxoCentro.y, 17, WHITE);
+            DrawText(TextFormat("Raio = %.1f", obstCircRaio),
+                     obstCircCentro.x, obstCircCentro.y, 17, WHITE);
 
             // FPS
             DrawFPS(10, 10);
@@ -108,7 +110,7 @@ int main(void)
 
 
 void MoverJog(Vector2* posAtual, Rectangle obRet,
-                Vector2 obCircCentro, float raio)
+                Vector2 obCircCentro, float obstRaio)
 {
     // Posicao do player no proximo frame em relacao ah posicao atual
     Vector2 playerMoveTo = Vector2Zero();
@@ -129,19 +131,19 @@ void MoverJog(Vector2* posAtual, Rectangle obRet,
        A magnitude desse vetor eh sqrt(1^2 + 1^2) = ~1.41 */
 
     /* Se o raio for menor que 0, tornah-lo 0. Note que isso nao afeta nada
-       fora da funcao (pq raio nao eh ponteiro). */
-    raio = (raio < 0) ? 0 : raio;
+       fora da funcao (pq obstRaio nao eh ponteiro). */
+    obstRaio = (obstRaio < 0) ? 0 : obstRaio;
 
     // Verificar colisao
     if (!CheckCollisionCircleRec(playerMoveTo, RAIO_PLR, obRet) &&
-        !CheckCollisionCircles(playerMoveTo, RAIO_PLR, obCircCentro, raio))
+        !CheckCollisionCircles(playerMoveTo, RAIO_PLR, obCircCentro, obstRaio))
     {
         // Atualizar a posicao do player
         *posAtual = playerMoveTo;
     }
 }
 
-void MoverObst(Rectangle* obstRet, Vector2* obRoxoCentro,
+void MoverObst(Rectangle* obstRet, Vector2* circCentro,
                    float* raio, bool* roxoTaAndando)
 {
     // Mover o retangulo
@@ -152,7 +154,7 @@ void MoverObst(Rectangle* obstRet, Vector2* obRoxoCentro,
     // Mover o roxo
     if (IsKeyDown(KEY_SPACE)) {
         *roxoTaAndando = true;
-        obRoxoCentro->x -= VEL_ROXO * GetFrameTime();
+        circCentro->x -= VEL_ROXO * GetFrameTime();
         *raio -= VEL_ROXO / 5.0f * GetFrameTime();
     } else {
         *roxoTaAndando = false;


### PR DESCRIPTION
Muda os nomes no código de inglês para português. Antes tava uma mistura muito loka. Se tiver algum nome ainda em inglês (que não seja do Raylib, claro), não foi intencional.

Também tem mais algumas outras refatorações pequenas (principalmente, ao invés de chamar os obstáculos pelas suas cores, agora seus nomes referem-se aos seus formatos).